### PR TITLE
don't declare as a module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@efstajas/gql-iterate",
-  "type": "module",
   "version": "0.1.2",
   "description": "🔁📃🪐 A CL tool for running the same GQL query repeatedly with variable values from a CSV.",
   "keywords": ["GraphQL", "CSV", "utility", "command-line", "cli", "tool"],


### PR DESCRIPTION
Fixes:
```
C:\Dev\gql-iterate> nvs
PATH -= $env:LOCALAPPDATA\nvs\default
PATH += $env:LOCALAPPDATA\nvs\node\14.15.0\x64

C:\Dev\gql-iterate> node .
file:///C:/Dev/gql-iterate/bin/cli.js:3
const { GraphQLClient, gql } = require('graphql-request')
                               ^

ReferenceError: require is not defined
    at file:///C:/Dev/gql-iterate/bin/cli.js:3:32
    at ModuleJob.run (internal/modules/esm/module_job.js:146:23)
    at async Loader.import (internal/modules/esm/loader.js:165:24)
    at async Object.loadESM (internal/process/esm_loader.js:68:5)
```

A quick search revealed that using `"type": "module"` in `package.json` will mark the package type as module, which disables some CommonJS features, like the `require` function.
This project does not seem to use any ES Modules features.
https://stackoverflow.com/a/60226186